### PR TITLE
cmd/perflock: default -governor to "none"

### DIFF
--- a/cmd/perflock/main.go
+++ b/cmd/perflock/main.go
@@ -53,18 +53,21 @@ func main() {
 		fmt.Fprintf(os.Stderr, "\n")
 		flag.PrintDefaults()
 	}
-	flagDaemon := flag.Bool("daemon", false, "start perflock daemon")
+	flagDaemon := flag.Bool("daemon", false, "start perflock daemon, defaulting to -governor=90%")
 	flagList := flag.Bool("list", false, "print current and pending commands")
 	flagSocket := flag.String("socket", "/var/run/perflock.socket", "connect to socket `path`")
 	flagShared := flag.Bool("shared", false, "acquire lock in shared mode (default: exclusive mode)")
-	flagGovernor := &governorFlag{percent: 90}
-	flag.Var(flagGovernor, "governor", "set CPU frequency to `percent` between the min and max\n\twhile running command, or \"none\" for no adjustment")
+	flagGovernor := &governorFlag{percent: -1}
+	flag.Var(flagGovernor, "governor", "override the CPU frequency to `percent` between the min and max")
 	flag.Parse()
 
 	if *flagDaemon {
 		if flag.NArg() > 0 {
 			flag.Usage()
 			os.Exit(2)
+		}
+		if flagGovernor.percent == 0 {
+			flagGovernor.percent = 90
 		}
 		doDaemon(*flagSocket)
 		return

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/aclements/perflock
+
+go 1.11


### PR DESCRIPTION
I've been a perflock user for over a year, and I still couldn't
understand why the setup below wouldn't work:

	# start the server
	sudo perflock -daemon -governor 70%
	# run a command
	perflock go test -bench=.

Whatever -governor flag I used for the daemon, it seemed like the actual
cpu frequency was locked at 90%. Only after some println debugging I
figured out the reason: the second command runs the perflock client,
which also defaults -governor to 90%. And the client sends that setting
to the daemon when running a command.

All in all, I should have been using the client like 'perflock
-governor=none', but that seems overly verbose and backwards. I'm not
setting a governor in the client, so presumably I'm not overriding the
daemon's explicit setting.

The other option would be to not set up the governor in the daemon, and
set it on each client run. However, that's also unnecessarily verbose;
in general, most benchmarks will need the same CPU settings. For
example, my laptop tends to overheat and throttle past 80%, so I tend to
default to 70%.

Instead, default -governor to "none", and have -daemon fall back to the
reasonable default of 90% if -governor=none. This way, we don't break
current uses of the daemon, and it's possible to use perflock with the
daemon's governor setting without adding an explicit -governor=none.

While at it, add a tiny go.mod.